### PR TITLE
change node-sass version to 4.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	],
 	"main": "lib/",
 	"dependencies": {
-		"node-sass": "~0.6.4",
+		"node-sass": "~4.14.1",
 		"clean-css": "~1.0.12"
 	},
 	"devDependencies": {


### PR DESCRIPTION
I was getting a gyp build error with v. 0.64. Updated to the latest node-sass version (4.14.1)